### PR TITLE
Improve muscle selection view

### DIFF
--- a/src/app/components/select-program/select-program.component.html
+++ b/src/app/components/select-program/select-program.component.html
@@ -3,10 +3,11 @@
   <button class="btn btn-primary align-self-start" (click)="toggleMuscleGroups()">Create a program</button>
 
   <div *ngIf="showMuscleGroups" class="mt-3">
-    <div class="d-flex flex-wrap gap-2">
-      <button *ngFor="let muscle of muscleGroups" class="btn btn-outline-secondary" (click)="selectMuscle(muscle)">
-        {{ muscle }}
-      </button>
+    <div class="muscle-grid">
+      <div *ngFor="let muscle of muscleGroups" class="muscle-card" (click)="selectMuscle(muscle)">
+        <img [src]="muscleImages[muscle]" [alt]="muscle" />
+        <span>{{ muscle }}</span>
+      </div>
     </div>
 
     <div *ngIf="selectedMuscle" class="mt-4">

--- a/src/app/components/select-program/select-program.component.scss
+++ b/src/app/components/select-program/select-program.component.scss
@@ -1,3 +1,30 @@
 .page-title {
   color: #179ee3;
 }
+
+.muscle-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+
+.muscle-card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: box-shadow 0.3s ease;
+
+  &:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  img {
+    width: 60px;
+    height: 60px;
+    object-fit: contain;
+    margin-bottom: 0.5rem;
+  }
+}

--- a/src/app/components/select-program/select-program.component.ts
+++ b/src/app/components/select-program/select-program.component.ts
@@ -17,6 +17,20 @@ export class SelectProgramComponent {
   showMuscleGroups = false;
   selectedMuscle: string | null = null;
 
+  muscleImages: { [key: string]: string } = {
+    Chest: 'assets/muscles/chest.png',
+    Shoulders: 'assets/muscles/shoulders.png',
+    Triceps: 'assets/muscles/tricpes.png',
+    Back: 'assets/muscles/back.png',
+    Biceps: 'assets/muscles/biceps.png',
+    Quads: 'assets/muscles/quads.png',
+    Hamstrings: 'assets/muscles/hamstrings.png',
+    Calves: 'assets/muscles/claves.png',
+    Abs: 'assets/muscles/abs.png',
+    Glutes: 'assets/muscles/glutes.png',
+    Cardio: 'assets/muscles/cardio.png'
+  };
+
   muscleGroups: string[] = [
     'Chest',
     'Shoulders',


### PR DESCRIPTION
## Summary
- display muscles using cards instead of buttons
- add mapping for muscle images
- style new muscle card grid

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab1c5369c8331b8c1334c3eae9dfb