### PR TITLE
Add global service for program data

### DIFF
--- a/src/app/components/select-program/select-program.component.ts
+++ b/src/app/components/select-program/select-program.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { GeneralService } from 'src/general.service';
 
 interface Exercise {
   name: string;
@@ -14,6 +15,8 @@ interface Exercise {
   styleUrls: ['./select-program.component.scss']
 })
 export class SelectProgramComponent {
+  constructor(private gs: GeneralService) {}
+
   showMuscleGroups = false;
   selectedMuscle: string | null = null;
 
@@ -118,5 +121,9 @@ export class SelectProgramComponent {
 
   selectMuscle(muscle: string): void {
     this.selectedMuscle = muscle;
+  }
+
+  addExerciseToProgram(ex: Exercise): void {
+    this.gs.addExerciseToProgram(ex);
   }
 }

--- a/src/general.service.ts
+++ b/src/general.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GeneralService {
+  public progrem: any[] = [];
+
+  constructor() {}
+
+  addExerciseToProgram(item: any): void {
+    this.progrem.push(item);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `GeneralService` with a `progrem` array and helper method
- inject the service into `SelectProgramComponent` and provide a wrapper to add exercises

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686ab46c42088331a5c8359ea1731a75