### PR TITLE
Add multi-select support for dropdown

### DIFF
--- a/src/app/components/dropdown/dropdown.component.html
+++ b/src/app/components/dropdown/dropdown.component.html
@@ -1,11 +1,19 @@
 <div class="dropdown" [class.show]="menuOpen">
   <button type="button" class="btn btn-secondary dropdown-toggle" (click)="toggleMenu()" aria-expanded="menuOpen">
-    {{ text }}
+    {{ displayText }}
   </button>
-  <ul class="dropdown-menu" [class.show]="menuOpen" style="max-height: 300px; overflow-y: auto;">
+  <ul class="dropdown-menu" [class.show]="menuOpen" style="max-height: 300px; overflow-y: auto">
     <li *ngFor="let item of items">
-      <span *ngIf="itemDisplayKey" class="dropdown-item" style="cursor: pointer;" (click)="itemClick(item[itemDisplayKey])">{{ item[itemDisplayKey] }}</span>
-      <span *ngIf="!itemDisplayKey" class="dropdown-item" style="cursor: pointer;" (click)="itemClick(item)">{{ item }}</span>
+      <span class="dropdown-item" style="cursor: pointer" (click)="itemClick(item)">
+        <input
+          *ngIf="isMultipleSelection"
+          type="checkbox"
+          class="form-check-input me-2"
+          [checked]="item.selected"
+          (click)="$event.stopPropagation(); itemClick(item)"
+        />
+        {{ itemDisplayKey ? item[itemDisplayKey] : item }}
+      </span>
     </li>
   </ul>
 </div>

--- a/src/app/components/dropdown/dropdown.component.html
+++ b/src/app/components/dropdown/dropdown.component.html
@@ -3,17 +3,23 @@
     {{ displayText }}
   </button>
   <ul class="dropdown-menu" [class.show]="menuOpen" style="max-height: 300px; overflow-y: auto">
-    <li *ngFor="let item of items">
-      <span class="dropdown-item" style="cursor: pointer" (click)="itemClick(item)">
-        <input
-          *ngIf="isMultipleSelection"
-          type="checkbox"
-          class="form-check-input me-2"
-          [checked]="item.selected"
-          (click)="$event.stopPropagation(); itemClick(item)"
-        />
-        {{ itemDisplayKey ? item[itemDisplayKey] : item }}
-      </span>
-    </li>
+    <div *ngIf="items">
+      <li *ngFor="let item of items; let i = index"
+          [ngClass]="{'border border-primary': selectedIndex === i}">
+        <span class="dropdown-item" style="cursor: pointer" (click)="itemClick(item, i)">
+          <input
+            *ngIf="isMultipleSelection"
+            type="checkbox"
+            class="form-check-input me-2"
+            id="checkbox{{itemDisplayKey ? item[itemDisplayKey] : item}}"
+            (click)="$event.stopPropagation(); itemClick(item, i)"
+          />
+          {{ itemDisplayKey ? item[itemDisplayKey] : item }}
+        </span>
+      </li>
+    </div>
+    <div style="display: contents;">
+      <ng-content></ng-content>
+    </div>
   </ul>
 </div>

--- a/src/app/components/dropdown/dropdown.component.ts
+++ b/src/app/components/dropdown/dropdown.component.ts
@@ -1,11 +1,12 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-dropdown',
   templateUrl: './dropdown.component.html',
   styleUrls: ['./dropdown.component.scss'],
 })
-export class DropdownComponent {
+export class DropdownComponent implements OnInit {
   @Input() items: any[] = [];
   @Input() text = 'Select';
   @Input() itemDisplayKey = '';
@@ -13,44 +14,22 @@ export class DropdownComponent {
   @Output() onItemClick = new EventEmitter<any>();
 
   menuOpen = false;
+  displayText = '';
+  selectedIndex: number | null = null;
+  _=_;
 
-  get displayText(): string {
-    if (this.isMultipleSelection) {
-      const selectedItems = this.items.filter((i) => i && i.selected);
-      if (selectedItems.length) {
-        return selectedItems.map((i) => (this.itemDisplayKey ? i[this.itemDisplayKey] : i)).join(', ');
-      }
-    } else {
-      const selectedItem = this.items.find((i) => i && i.selected);
-      if (selectedItem) {
-        return this.itemDisplayKey ? selectedItem[this.itemDisplayKey] : selectedItem;
-      }
-    }
-    return this.text || 'Select';
+  ngOnInit() {
+    this.displayText = 'Select';
   }
 
   toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
   }
 
-  itemClick(item: any): void {
-    if (this.isMultipleSelection) {
-      if (item && typeof item === 'object') {
-        item.selected = !item.selected;
-      }
-      // keep menu open for multiple selection
-    } else {
-      this.menuOpen = false;
-      this.items.forEach((i) => {
-        if (i && typeof i === 'object') {
-          i.selected = false;
-        }
-      });
-      if (item && typeof item === 'object') {
-        item.selected = true;
-      }
-    }
-
+  itemClick(item: any, index: number): void {
+    this.selectedIndex = index;
+    this.menuOpen = false;
+    this.displayText = (this.displayText === item) ? 'Select' : item;
     const emitItem = this.itemDisplayKey && !this.isMultipleSelection ? item[this.itemDisplayKey] : item;
     this.onItemClick.emit(emitItem);
   }

--- a/src/app/components/dropdown/dropdown.component.ts
+++ b/src/app/components/dropdown/dropdown.component.ts
@@ -7,18 +7,51 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 })
 export class DropdownComponent {
   @Input() items: any[] = [];
-  @Input() text = '';
+  @Input() text = 'Select';
   @Input() itemDisplayKey = '';
+  @Input() isMultipleSelection = false;
   @Output() onItemClick = new EventEmitter<any>();
 
   menuOpen = false;
+
+  get displayText(): string {
+    if (this.isMultipleSelection) {
+      const selectedItems = this.items.filter((i) => i && i.selected);
+      if (selectedItems.length) {
+        return selectedItems.map((i) => (this.itemDisplayKey ? i[this.itemDisplayKey] : i)).join(', ');
+      }
+    } else {
+      const selectedItem = this.items.find((i) => i && i.selected);
+      if (selectedItem) {
+        return this.itemDisplayKey ? selectedItem[this.itemDisplayKey] : selectedItem;
+      }
+    }
+    return this.text || 'Select';
+  }
 
   toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
   }
 
   itemClick(item: any): void {
-    this.menuOpen = false;
-    this.onItemClick.emit(item);
+    if (this.isMultipleSelection) {
+      if (item && typeof item === 'object') {
+        item.selected = !item.selected;
+      }
+      // keep menu open for multiple selection
+    } else {
+      this.menuOpen = false;
+      this.items.forEach((i) => {
+        if (i && typeof i === 'object') {
+          i.selected = false;
+        }
+      });
+      if (item && typeof item === 'object') {
+        item.selected = true;
+      }
+    }
+
+    const emitItem = this.itemDisplayKey && !this.isMultipleSelection ? item[this.itemDisplayKey] : item;
+    this.onItemClick.emit(emitItem);
   }
 }

--- a/src/app/components/select-program/select-program.component.html
+++ b/src/app/components/select-program/select-program.component.html
@@ -16,13 +16,13 @@
         </button>
       </div>
       <!--search-->
-      <div class="d-flex flex-row align-items-center">
+      <div class="d-flex flex-column gap-2">
         <input type="text" class="form-control" style="width: 250px;" [(ngModel)]="searchText" placeholder="Search exercises" (input)="searchExercises()">
-        <div class="d-flex flex-row align-items-center gap-2">
+        <div class="d-flex flex-row align-items-center gap-2" *ngIf="exerciseService.categories">
           <span>Filter by categories</span>
           <app-dropdown [text]="'Select'" [items]="exerciseService.categories" (onItemClick)="searchExercises($event)"></app-dropdown>
         </div>
-        <div class="d-flex flex-row align-items-center gap-2">
+        <div class="d-flex flex-row align-items-center gap-2" *ngIf="exerciseService.muscleGroups">
           <span>Filter by muscles group</span>
           <app-dropdown [text]="'Select'" [items]="exerciseService.muscleGroups" (onItemClick)="searchExercises($event)"></app-dropdown>
         </div>
@@ -30,7 +30,7 @@
     <div class="animated-container">
       <div class="row g-3">
         <ng-container *ngFor="let day of ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']">
-          <div class="col-12" *ngIf="selectedDay === day">
+          <div class="col-6" *ngIf="selectedDay === day">
             <span class="mb-3">Select exercises for the selected day</span>
             <div class="row g-3 overflow-auto" style="max-height: 500px;">
               <div class="col-12 col-sm-6 col-md-4 col-lg-3" *ngFor="let exercise of exerciseService.exercises" [hidden]="exercise.show">
@@ -50,13 +50,27 @@
                 </div>
               </div>
             </div>
-            <div *ngIf="newProgram.exercises[day].programs.length" class="mt-3">
-              <hr/>
-              <div *ngFor="let ex of newProgram.exercises[day].programs">
-                <div class="d-flex align-items-center gap-2 mb-2">
-                  <span>{{ ex.name }}</span>
-                  <!-- Add more exercise details here if needed -->
+          </div>
+          <div *ngIf="newProgram.exercises[day].programs.length" class="col-6">
+            <hr/>
+            <div *ngFor="let ex of newProgram.exercises[day].programs">
+              <div class="d-flex gap-2 mb-2 border rounded" style="height: 200px;">
+                <div class="overflow-hidden" style="width: 120px; height: 120px;">
+                  <img [src]="ex.images[0]" alt="{{ ex.name }}" class="img-fluid rounded" style="max-height: 100%; object-fit: cover;">
                 </div>
+                <div class="d-flex flex-column gap-1">
+                  <span style="font-size: 1.4rem; font-weight: bold;">{{ ex.name }}</span>
+                  <div class="px-1 rounded bg-danger bg-opacity-50" style="cursor: pointer; width: fit-content;" (click)="addWeight(day, ex)">
+                    <span class="text-white" style="font-size: 0.9rem;">{{'Add Weight +'}}</span>
+                  </div>
+                  <div class="px-1 rounded bg-danger bg-opacity-50" style="cursor: pointer; width: fit-content;" (click)="addWeight(day, ex)">
+                    <span class="text-white" style="font-size: 0.9rem;">{{'Add Reps and times +'}}</span>
+                  </div>
+                </div>
+                <!--<div class="text-danger border border-danger rounded" style="cursor: pointer;">
+                  <i class="fas fa-times"></i> remove
+                </div>-->
+                <!-- Add more exercise details here if needed -->
               </div>
             </div>
           </div>
@@ -71,36 +85,4 @@
         </button>
       </div>
     </div>
-  <!--<div *ngIf="showMuscleGroups" class="mt-3">
-    <div class="muscle-grid">
-      <div *ngFor="let muscle of muscleGroups" class="muscle-card" (click)="selectMuscle(muscle)">
-        <img [src]="muscleImages[muscle]" [alt]="muscle" />
-        <span>{{ muscle }}</span>
-      </div>
-    </div>
-
-    <div *ngIf="selectedMuscle" class="mt-4">
-      <h5>{{ selectedMuscle }} Exercises</h5>
-      <div class="table-responsive">
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th>Exercise</th>
-              <th>Reps</th>
-              <th>Sets</th>
-              <th>Rest</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr *ngFor="let ex of filteredExercises">
-              <td>{{ ex.name }}</td>
-              <td>{{ ex.reps }}</td>
-              <td>{{ ex.times }}</td>
-              <td>{{ ex.rest_between }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>-->
 </div>

--- a/src/app/components/select-program/select-program.component.ts
+++ b/src/app/components/select-program/select-program.component.ts
@@ -99,4 +99,8 @@ export class SelectProgramComponent {
       exercise.show = !(matchesSearch && matchesFilter);
     });
   }
+
+  addWeight = (day:any ,exercise: any) => {
+
+  }
 }


### PR DESCRIPTION
## Summary
- add `isMultipleSelection` input to `app-dropdown`
- keep dropdown open when multi-selecting items
- show checkboxes when multiple selection is enabled
- show selected items in dropdown button text

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e64f8a64083319a50c204f1134bb5