### PR TITLE
Add multi-select support for dropdown

### DIFF
--- a/src/app/components/dropdown/dropdown.component.html
+++ b/src/app/components/dropdown/dropdown.component.html
@@ -1,11 +1,19 @@
 <div class="dropdown" [class.show]="menuOpen">
   <button type="button" class="btn btn-secondary dropdown-toggle" (click)="toggleMenu()" aria-expanded="menuOpen">
-    {{ text }}
+    {{ displayText }}
   </button>
-  <ul class="dropdown-menu" [class.show]="menuOpen" style="max-height: 300px; overflow-y: auto;">
+  <ul class="dropdown-menu" [class.show]="menuOpen" style="max-height: 300px; overflow-y: auto">
     <li *ngFor="let item of items">
-      <span *ngIf="itemDisplayKey" class="dropdown-item" style="cursor: pointer;" (click)="itemClick(item[itemDisplayKey])">{{ item[itemDisplayKey] }}</span>
-      <span *ngIf="!itemDisplayKey" class="dropdown-item" style="cursor: pointer;" (click)="itemClick(item)">{{ item }}</span>
+      <span class="dropdown-item" style="cursor: pointer" (click)="itemClick(item)">
+        <input
+          *ngIf="isMultipleSelection"
+          type="checkbox"
+          class="form-check-input me-2"
+          [checked]="item.selected"
+          (click)="$event.stopPropagation(); itemClick(item)"
+        />
+        {{ getItemLabel(item) }}
+      </span>
     </li>
   </ul>
 </div>

--- a/src/app/components/dropdown/dropdown.component.ts
+++ b/src/app/components/dropdown/dropdown.component.ts
@@ -7,18 +7,69 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 })
 export class DropdownComponent {
   @Input() items: any[] = [];
-  @Input() text = '';
+  @Input() text = 'Select';
   @Input() itemDisplayKey = '';
+  @Input() itemValueKey = '';
+  @Input() isMultipleSelection = false;
   @Output() onItemClick = new EventEmitter<any>();
 
   menuOpen = false;
+
+  get displayText(): string {
+    if (this.isMultipleSelection) {
+      const selectedItems = this.items.filter((i) => i && i.selected);
+      if (selectedItems.length) {
+        return selectedItems.map((i) => this.getItemLabel(i)).join(', ');
+      }
+    } else {
+      const selectedItem = this.items.find((i) => i && i.selected);
+      if (selectedItem) {
+        return this.getItemLabel(selectedItem);
+      }
+    }
+    return this.text || 'Select';
+  }
+
+  getItemLabel(item: any): string {
+    if (item === null || item === undefined) {
+      return '';
+    }
+    if (typeof item === 'object') {
+      if (this.itemDisplayKey && item[this.itemDisplayKey] !== undefined) {
+        return String(item[this.itemDisplayKey]);
+      }
+      const firstKey = Object.keys(item)[0];
+      return firstKey ? String(item[firstKey]) : '';
+    }
+    return String(item);
+  }
 
   toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
   }
 
   itemClick(item: any): void {
-    this.menuOpen = false;
-    this.onItemClick.emit(item);
+    if (this.isMultipleSelection) {
+      if (item && typeof item === 'object') {
+        item.selected = !item.selected;
+      }
+      // keep menu open for multiple selection
+    } else {
+      this.menuOpen = false;
+      this.items.forEach((i) => {
+        if (i && typeof i === 'object') {
+          i.selected = false;
+        }
+      });
+      if (item && typeof item === 'object') {
+        item.selected = true;
+      }
+    }
+
+    let emitItem: any = item;
+    if (this.itemValueKey && item && typeof item === 'object') {
+      emitItem = item[this.itemValueKey];
+    }
+    this.onItemClick.emit(emitItem);
   }
 }


### PR DESCRIPTION
## Summary
- add `isMultipleSelection` input to `app-dropdown`
- keep dropdown open when multi-selecting items
- show checkboxes when multiple selection is enabled
- show selected items in dropdown button text
- handle object items using `itemDisplayKey` and new `itemValueKey`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e64f8a64083319a50c204f1134bb5