### PR TITLE
Add saveable daily programs

### DIFF
--- a/src/app/components/select-program/select-program.component.html
+++ b/src/app/components/select-program/select-program.component.html
@@ -7,14 +7,6 @@
         <label for="programName" class="form-label">Program Name</label>
         <input type="text" class="form-control" id="programName" [(ngModel)]="newProgram.name" placeholder="Enter program name">
       </div>
-      <div class="d-flex align-items-center gap-2 flex-wrap my-3">
-        <button
-          class="btn btn-outline-primary" [ngClass]="{'active': selectedDay === day}"
-          *ngFor="let day of ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']"
-          (click)="onDayClick(day)">
-          {{ day }}
-        </button>
-      </div>
       <!--search-->
       <div class="d-flex flex-column gap-2">
         <input type="text" class="form-control" style="width: 250px;" [(ngModel)]="searchText" placeholder="Search exercises" (input)="searchExercises()">
@@ -29,9 +21,10 @@
       </div>
     <div class="animated-container">
       <div class="row g-3">
-        <ng-container *ngFor="let day of ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']">
-          <div class="col-6" *ngIf="selectedDay === day">
+        <ng-container>
+          <div class="col-6">
             <span class="mb-3">Select exercises for the selected day</span>
+            <button class="btn btn-outline-warning mb-2" (click)="addExercise({name: 'Rest'})">Rest</button>
             <div class="row g-3 overflow-auto" style="max-height: 500px;">
               <div class="col-12 col-sm-6 col-md-4 col-lg-3" *ngFor="let exercise of exerciseService.exercises" [hidden]="exercise.show">
                 <div class="card exercise-card rounded overflow-hidden d-flex flex-column align-items-center" (click)="addExercise(exercise)" style="cursor: pointer;">
@@ -51,31 +44,32 @@
               </div>
             </div>
           </div>
-          <div *ngIf="newProgram.exercises[day].programs.length" class="col-6">
-            <hr/>
-            <div *ngFor="let ex of newProgram.exercises[day].programs">
-              <div class="d-flex gap-2 mb-2 border rounded" style="height: 200px;">
-                <div class="overflow-hidden" style="width: 120px; height: 120px;">
-                  <img [src]="ex.images[0]" alt="{{ ex.name }}" class="img-fluid rounded" style="max-height: 100%; object-fit: cover;">
+          <div class="col-6">
+            <div *ngFor="let ex of newProgram.exercises">
+              <div class="d-flex flex-column mb-2 border rounded position-relative" style="height: 200px;">
+                <div class="position-absolute" style="top: 5px; right: 5px;">
+                  <button class="btn btn-link text-danger" (click)="removeExercise(ex)">
+                    <i class="fas fa-times"></i>
+                  </button>
                 </div>
-                <div class="d-flex flex-column gap-1">
-                  <span style="font-size: 1.4rem; font-weight: bold;">{{ ex.name }}</span>
-                  <div class="px-1 rounded bg-danger bg-opacity-50" style="cursor: pointer; width: fit-content;" (click)="addWeight(day, ex)">
-                    <span class="text-white" style="font-size: 0.9rem;">{{'Add Weight +'}}</span>
+                <div class="d-flex gap-2">
+                  <div *ngIf="ex.name !== 'Rest'" class="overflow-hidden" style="width: 120px; height: 120px;">
+                    <img [src]="ex.images[0]" alt="{{ ex.name }}" class="img-fluid rounded" style="max-height: 100%; object-fit: cover;">
                   </div>
-                  <div class="px-1 rounded bg-danger bg-opacity-50" style="cursor: pointer; width: fit-content;" (click)="addWeight(day, ex)">
-                    <span class="text-white" style="font-size: 0.9rem;">{{'Add Reps and times +'}}</span>
+                  <div class="d-flex flex-column gap-1">
+                    <span style="font-size: 1.4rem; font-weight: bold;">{{ ex.name }}</span>
+                    <div *ngIf="ex.name !== 'Rest'" class="px-1 rounded bg-danger bg-opacity-50" style="cursor: pointer; width: fit-content;" (click)="addWeight(ex)">
+                      <span class="text-white" style="font-size: 0.9rem;">{{ex.weight ? ex.weight + ' KG ' : 'Add Weight'}} <i class="fas fa-edit ms-1"></i></span>
+                    </div>
+                    <div *ngIf="ex.name !== 'Rest'" class="px-1 rounded bg-danger bg-opacity-50" style="cursor: pointer; width: fit-content;">
+                      <span class="text-white" style="font-size: 0.9rem;">{{'Add Reps and times +'}}</span>
+                    </div>
+                    <div *ngIf="ex.name === 'Rest'" class="px-1 rounded bg-danger bg-opacity-50" style="cursor: pointer; width: fit-content;">
+                      <span class="text-white" style="font-size: 0.9rem;">{{'Add time +'}}</span>
+                    </div>
                   </div>
                 </div>
-                <!--<div class="text-danger border border-danger rounded" style="cursor: pointer;">
-                  <i class="fas fa-times"></i> remove
-                </div>-->
-                <!-- Add more exercise details here if needed -->
               </div>
-            </div>
-            <div class="mt-3">
-              <input type="text" class="form-control mb-2" placeholder="Program name" [(ngModel)]="dayProgramName">
-              <button class="btn btn-primary" (click)="saveDayProgram()">Save Program</button>
             </div>
           </div>
         </ng-container>
@@ -84,7 +78,7 @@
     <div *ngIf="gs.savedPrograms.length" class="mt-3">
       <span>Saved Programs:</span>
       <div class="d-flex flex-wrap gap-2 mt-1">
-        <button *ngFor="let sp of gs.savedPrograms" class="btn btn-outline-secondary" (click)="applySavedProgram(sp)">
+        <button *ngFor="let sp of gs.savedPrograms" class="btn btn-outline-secondary">
           {{ sp.name }}
         </button>
       </div>
@@ -97,4 +91,44 @@
         </button>
       </div>
     </div>
+</div>
+
+<!-- Add Weight popup -->
+<div *ngIf="addWeightPopup?.show" class="popup-overlay">
+  <div class="popup-wrapper">
+    <div class="popup-content" style="width: 300px;">
+      <div class="popup-header">
+        <span class="popup-title" style="font-weight: bold; font-size: 1.2rem;">Add Weight</span>
+        <span class="popup-subtitle text-muted" style="font-weight: bold;">Select weight for the: {{addWeightPopup.exercise.name}}</span>
+      </div>
+      <div class="popup-body">
+        <select class="form-select overflow-auto" [(ngModel)]="addWeightPopup.weight" size="3">
+          <option *ngFor="let w of [].constructor(401); let i = index" [value]="i * 0.5">{{ i * 0.5 }} kg</option>
+        </select>
+      </div>
+      <div class="popup-footer">
+        <button class="btn btn-secondary" (click)="addWeightPopup = null;">Cancel</button>
+        <button class="btn btn-primary" (click)="addWeightPopup.confirm();">Confirm</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Add res -->
+<div *ngIf="addRepsPopup?.show" class="popup-overlay">
+  <div class="popup-wrapper">
+    <div class="popup-content" style="width: 300px;">
+      <div class="popup-header">
+        <span class="popup-title" style="font-weight: bold; font-size: 1.2rem;">Add Reps</span>
+        <span class="popup-subtitle text-muted" style="font-weight: bold;">Select how many reps and how many times you want it</span>
+      </div>
+      <div class="popup-body">
+
+      </div>
+      <div class="popup-footer">
+        <button class="btn btn-secondary" (click)="addRepsPopup = null;">Cancel</button>
+        <button class="btn btn-primary" (click)="addRepsPopup.confirm();">Confirm</button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/components/select-program/select-program.component.html
+++ b/src/app/components/select-program/select-program.component.html
@@ -73,8 +73,20 @@
                 <!-- Add more exercise details here if needed -->
               </div>
             </div>
+            <div class="mt-3">
+              <input type="text" class="form-control mb-2" placeholder="Program name" [(ngModel)]="dayProgramName">
+              <button class="btn btn-primary" (click)="saveDayProgram()">Save Program</button>
+            </div>
           </div>
         </ng-container>
+      </div>
+    </div>
+    <div *ngIf="gs.savedPrograms.length" class="mt-3">
+      <span>Saved Programs:</span>
+      <div class="d-flex flex-wrap gap-2 mt-1">
+        <button *ngFor="let sp of gs.savedPrograms" class="btn btn-outline-secondary" (click)="applySavedProgram(sp)">
+          {{ sp.name }}
+        </button>
       </div>
     </div>
       <!-- Add more fields as needed -->

--- a/src/app/components/select-program/select-program.component.scss
+++ b/src/app/components/select-program/select-program.component.scss
@@ -47,3 +47,52 @@
     transition: box-shadow 0.2s, border 0.2s, background 0.2s;
   }
 }
+
+.popup-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  .popup-wrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .popup-content {
+      display: flex;
+      flex-direction: column;
+
+      background-color: white;
+      border-radius: 8px;
+      border: 1px solid #ddd;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+
+      .popup-header {
+        padding: 0.5rem 1rem;
+        background-color: rgba(129, 197, 255, 0.8);
+        border-bottom: 1px solid #ddd;
+        display: flex;
+        flex-direction:column;
+        gap: 0.2rem;
+      }
+
+      .popup-body {
+        display: flex;
+        flex-direction: column;
+        padding: 0.3rem 1rem;
+        flex-grow: 1;
+      }
+
+      .popup-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.2rem;
+        padding: 0.5rem 1rem;
+      }
+    }
+  }
+}

--- a/src/app/components/select-program/select-program.component.ts
+++ b/src/app/components/select-program/select-program.component.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
   styleUrls: ['./select-program.component.scss']
 })
 export class SelectProgramComponent {
-  constructor(private gs: GeneralService, public exerciseService: ExerciseService) { }
+  constructor(public gs: GeneralService, public exerciseService: ExerciseService) { }
   newProgram:any;
   dayProgramName = '';
 
@@ -20,21 +20,15 @@ export class SelectProgramComponent {
   selectedDay = 'Sunday';
   searchText = '';
   activeFilters: string[] = [];
+  addWeightPopup:any;
+  addRepsPopup: any;
 
 
   createNewProgram(): void {
     this.newProgram = {
       name: '',
       description: '',
-      exercises: {
-        Sunday: { programs: [] },
-        Monday: { programs: [] },
-        Tuesday: { programs: [] },
-        Wednesday: { programs: [] },
-        Thursday: { programs: [] },
-        Friday: { programs: [] },
-        Saturday: { programs: [] }
-      },
+      exercises: [],
       duration: 0,
       level: '',
       category: '',
@@ -60,23 +54,12 @@ export class SelectProgramComponent {
   }
 
   addExercise = (exercise: any) => {
-    if (this.newProgram && this.newProgram.exercises && this.selectedDay) {
-      this.newProgram.exercises[this.selectedDay].programs.push(exercise);
-    }
+    this.newProgram.exercises.push(exercise);
   }
-
-  saveDayProgram() {
-    const exercises = this.newProgram?.exercises?.[this.selectedDay]?.programs || [];
-    if (!exercises.length || !this.dayProgramName.trim()) {
-      return;
-    }
-    this.gs.saveProgram({ name: this.dayProgramName.trim(), exercises: [...exercises] });
-    this.dayProgramName = '';
-  }
-
-  applySavedProgram(program: any) {
-    if (this.newProgram && this.selectedDay) {
-      this.newProgram.exercises[this.selectedDay].programs = [...program.exercises];
+  removeExercise = (exercise: any) => {
+    const index = this.newProgram.exercises.indexOf(exercise);
+    if (index > -1) {
+      this.newProgram.exercises.splice(index, 1);
     }
   }
 
@@ -116,7 +99,21 @@ export class SelectProgramComponent {
     });
   }
 
-  addWeight = (day:any ,exercise: any) => {
+  addWeight = (exercise: any) => {
+    this.addWeightPopup = {
+      show: true,
+      exercise: exercise,
+      weight: 0,
+      confirm: () => {
+        if (this.addWeightPopup.weight > 0) {
+          exercise.weight = this.addWeightPopup.weight;
+        }
+        this.addWeightPopup = null;
+      }
+    }
+  }
+
+  addRestTime = (day:any ,exercise: any) => {
 
   }
 }

--- a/src/app/components/select-program/select-program.component.ts
+++ b/src/app/components/select-program/select-program.component.ts
@@ -11,6 +11,7 @@ import * as _ from 'lodash';
 export class SelectProgramComponent {
   constructor(private gs: GeneralService, public exerciseService: ExerciseService) { }
   newProgram:any;
+  dayProgramName = '';
 
   imageIndexes: { [key: string]: number } = {};
 
@@ -61,6 +62,21 @@ export class SelectProgramComponent {
   addExercise = (exercise: any) => {
     if (this.newProgram && this.newProgram.exercises && this.selectedDay) {
       this.newProgram.exercises[this.selectedDay].programs.push(exercise);
+    }
+  }
+
+  saveDayProgram() {
+    const exercises = this.newProgram?.exercises?.[this.selectedDay]?.programs || [];
+    if (!exercises.length || !this.dayProgramName.trim()) {
+      return;
+    }
+    this.gs.saveProgram({ name: this.dayProgramName.trim(), exercises: [...exercises] });
+    this.dayProgramName = '';
+  }
+
+  applySavedProgram(program: any) {
+    if (this.newProgram && this.selectedDay) {
+      this.newProgram.exercises[this.selectedDay].programs = [...program.exercises];
     }
   }
 

--- a/src/app/services/general.service.ts
+++ b/src/app/services/general.service.ts
@@ -1,14 +1,19 @@
 import { Injectable } from '@angular/core';
 
+export interface SavedProgram {
+  name: string;
+  exercises: any[];
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class GeneralService {
-  public progrem: any[] = [];
+  public savedPrograms: SavedProgram[] = [];
 
   constructor() {}
 
-  addExerciseToProgram(item: any): void {
-    this.progrem.push(item);
+  saveProgram(program: SavedProgram): void {
+    this.savedPrograms.push(program);
   }
 }


### PR DESCRIPTION
## Summary
- save program structure in GeneralService
- allow naming and saving selected day exercises
- list saved programs and apply them to other days

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: ng not found)*
- `npx tsc -p tsconfig.app.json` *(fails: missing Angular dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872447e0658833184472895c61243ca