### PR TITLE
Add login with signup option

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,11 +3,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
 import { ProgramsComponent } from './components/programs/programs.component';
 import { AnalyicComponent } from './components/analyic/analyic.component'; // Adjust path if needed
+import { LoginComponent } from './components/login/login.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'programs', component: ProgramsComponent },
   { path: 'analytic', component: AnalyicComponent },
+  { path: 'login', component: LoginComponent },
   // Add more routes here if needed
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { CalendarModule, DateAdapter } from 'angular-calendar';
 import { adapterFactory } from 'angular-calendar/date-adapters/date-fns';
 import { CalanderComponent } from './components/calander/calander.component';
 import { DropdownComponent } from './components/dropdown/dropdown.component';
+import { LoginComponent } from './components/login/login.component';
 import { GeneralService } from './services/general.service';
 import { ExerciseService } from './services/exercise.service';
 import { HttpClientModule } from '@angular/common/http';
@@ -31,6 +32,7 @@ import { ToastrModule } from 'ngx-toastr';
     CalanderComponent,
     SelectProgramComponent,
     DropdownComponent,
+    LoginComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -1,0 +1,69 @@
+<div class="auth-container">
+  <div class="card p-4">
+    <h2 class="mb-4 text-center">{{ isSignup ? 'Sign Up' : 'Login' }}</h2>
+
+    <form *ngIf="!isSignup" (ngSubmit)="login()" #loginForm="ngForm">
+      <div class="mb-3">
+        <input
+          type="email"
+          class="form-control"
+          name="email"
+          placeholder="Email"
+          required
+          [(ngModel)]="loginData.email"
+        />
+      </div>
+      <div class="mb-3">
+        <input
+          type="password"
+          class="form-control"
+          name="password"
+          placeholder="Password"
+          required
+          [(ngModel)]="loginData.password"
+        />
+      </div>
+      <button class="btn btn-primary w-100" type="submit">Login</button>
+    </form>
+
+    <form *ngIf="isSignup" (ngSubmit)="signup()" #signupForm="ngForm">
+      <div class="mb-3">
+        <input
+          type="email"
+          class="form-control"
+          name="email"
+          placeholder="Email"
+          required
+          [(ngModel)]="signupData.email"
+        />
+      </div>
+      <div class="mb-3">
+        <input
+          type="password"
+          class="form-control"
+          name="password"
+          placeholder="Password"
+          required
+          [(ngModel)]="signupData.password"
+        />
+      </div>
+      <div class="mb-3">
+        <input
+          type="password"
+          class="form-control"
+          name="confirmPassword"
+          placeholder="Confirm Password"
+          required
+          [(ngModel)]="signupData.confirmPassword"
+        />
+      </div>
+      <button class="btn btn-primary w-100" type="submit">Sign Up</button>
+    </form>
+
+    <div class="text-center mt-3">
+      <a href="#" (click)="toggleMode(); $event.preventDefault()">
+        {{ isSignup ? 'Already have an account? Log in' : "Don't have an account? Sign up" }}
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/app/components/login/login.component.scss
+++ b/src/app/components/login/login.component.scss
@@ -1,0 +1,11 @@
+.auth-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 80vh;
+}
+
+.card {
+  max-width: 400px;
+  width: 100%;
+}

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss'],
+})
+export class LoginComponent {
+  isSignup = false;
+  loginData = { email: '', password: '' };
+  signupData = { email: '', password: '', confirmPassword: '' };
+
+  toggleMode() {
+    this.isSignup = !this.isSignup;
+  }
+
+  login() {
+    console.log('Logging in', this.loginData);
+  }
+
+  signup() {
+    console.log('Signing up', this.signupData);
+  }
+}


### PR DESCRIPTION
## Summary
- add LoginComponent with signup support
- wire up route to `/login`
- declare LoginComponent in `AppModule`

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687291574da4833180e94e72d7a62cc6