### PR TITLE
Add RouteService service

### DIFF
--- a/src/app/services/route.service.ts
+++ b/src/app/services/route.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteService {
+  private readonly baseUrl = 'http://localhost:3000';
+
+  constructor(private http: HttpClient) {}
+
+  login(data: unknown): Observable<unknown> {
+    return this.http.post<unknown>(`${this.baseUrl}/login`, data);
+  }
+
+  // additional backend calls can be placed here
+}


### PR DESCRIPTION
## Summary
- provide `RouteService` with a sample `login` method for backend requests

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687349eb9990833188c44556c3343774