### PR TITLE
Add auth guard and login persistence

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,13 +4,14 @@ import { HomeComponent } from './components/home/home.component';
 import { ProgramsComponent } from './components/programs/programs.component';
 import { AnalyicComponent } from './components/analyic/analyic.component'; // Adjust path if needed
 import { LoginComponent } from './components/login/login.component';
+import { AuthGuard } from './services/auth.guard';
 
 const routes: Routes = [
-  { path: '', component: HomeComponent },
-  { path: 'programs', component: ProgramsComponent },
-  { path: 'analytic', component: AnalyicComponent },
+  { path: '', component: HomeComponent, canActivate: [AuthGuard] },
+  { path: 'programs', component: ProgramsComponent, canActivate: [AuthGuard] },
+  { path: 'analytic', component: AnalyicComponent, canActivate: [AuthGuard] },
   { path: 'login', component: LoginComponent },
-  // Add more routes here if needed
+  { path: '**', redirectTo: '/login' },
 ];
 
 @NgModule({

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -20,16 +20,18 @@ export class LoginComponent {
   }
 
   login() {
-    this.authService.login(this.loginData.email, this.loginData.password).subscribe({
-      next: (res: any) => {
-        console.log('Login successful', res);
-        this.router.navigate(['/'], { state: { user: res.data } });
-      },
-      error: (err: any) => {
-        console.error('Login failed', err);
-        alert(err.error?.message || 'Login failed');
-      },
-    });
+    this.authService
+      .login(this.loginData.email, this.loginData.password)
+      .subscribe({
+        next: (res: any) => {
+          console.log('Login successful', res);
+          this.router.navigate(['/']);
+        },
+        error: (err: any) => {
+          console.error('Login failed', err);
+          alert(err.error?.message || 'Login failed');
+        },
+      });
   }
 
 
@@ -52,5 +54,10 @@ export class LoginComponent {
           alert(err.error?.message || 'Signup failed');
         },
       });
+  }
+
+  logout() {
+    this.authService.logout();
+    this.router.navigate(['/login']);
   }
 }

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -60,7 +60,7 @@
     </div>
   </div>
   <div class="mt-auto">
-    <div class="d-flex flex-row align-items-center gap-2 nav-item">
+    <div class="d-flex flex-row align-items-center gap-2 nav-item" (click)="logout()">
       <i class="fas fa-sign-out-alt"></i>
       <span style="font-size: 14px;">Logout</span>
     </div>

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { GeneralService } from '../../services/general.service';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-sidebar',
@@ -9,7 +11,7 @@ import { GeneralService } from '../../services/general.service';
 export class SidebarComponent implements OnInit {
   @Input() sidebarOpen: boolean = false;
   @Output() sidebarClose: EventEmitter<void> = new EventEmitter();
-  constructor(public gs: GeneralService) {}
+  constructor(public gs: GeneralService, private authService: AuthService, private router: Router) {}
 
   weekWorkouts = 0;
   savedProgram = this.gs.savedPrograms.length;
@@ -20,5 +22,10 @@ export class SidebarComponent implements OnInit {
 
   openCreateProgramPopup = () => {
 
+  }
+
+  logout() {
+    this.authService.logout();
+    this.router.navigate(['/login']);
   }
 }

--- a/src/app/services/auth.guard.ts
+++ b/src/app/services/auth.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthGuard implements CanActivate {
+  constructor(private authService: AuthService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    if (this.authService.isLoggedIn()) {
+      return true;
+    }
+
+    this.router.navigate(['/login']);
+    return false;
+  }
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { tap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -10,10 +11,30 @@ export class AuthService {
   constructor(private http: HttpClient) {}
 
   register(email: string, password: string) {
-    return this.http.post(`${this.baseUrl}/register`, { email, password });
+    return this.http.post<any>(`${this.baseUrl}/register`, { email, password }).pipe(
+      tap((res) => {
+        if (res && res.token) {
+          localStorage.setItem('token', res.token);
+        }
+      })
+    );
   }
 
   login(email: string, password: string) {
-    return this.http.post(`${this.baseUrl}/login`, { email, password });
+    return this.http.post<any>(`${this.baseUrl}/login`, { email, password }).pipe(
+      tap((res) => {
+        if (res && res.token) {
+          localStorage.setItem('token', res.token);
+        }
+      })
+    );
+  }
+
+  isLoggedIn(): boolean {
+    return !!localStorage.getItem('token');
+  }
+
+  logout(): void {
+    localStorage.removeItem('token');
   }
 }


### PR DESCRIPTION
## Summary
- persist authentication token in `AuthService`
- implement `AuthGuard` and protect main routes
- update login flows to rely on stored token
- wire up logout action in sidebar

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_687356300e8083318f065678578074f5