### PR TITLE
Implement authentication guard with token persistence

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,13 +4,14 @@ import { HomeComponent } from './components/home/home.component';
 import { ProgramsComponent } from './components/programs/programs.component';
 import { AnalyicComponent } from './components/analyic/analyic.component'; // Adjust path if needed
 import { LoginComponent } from './components/login/login.component';
+import { AuthGuard } from './services/auth.guard';
 
 const routes: Routes = [
-  { path: '', component: HomeComponent },
-  { path: 'programs', component: ProgramsComponent },
-  { path: 'analytic', component: AnalyicComponent },
+  { path: '', component: HomeComponent, canActivate: [AuthGuard] },
+  { path: 'programs', component: ProgramsComponent, canActivate: [AuthGuard] },
+  { path: 'analytic', component: AnalyicComponent, canActivate: [AuthGuard] },
   { path: 'login', component: LoginComponent },
-  // Add more routes here if needed
+  { path: '**', redirectTo: '/login' },
 ];
 
 @NgModule({

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { RouteService } from '../../services/route.service';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -9,7 +9,7 @@ import { RouteService } from '../../services/route.service';
 })
 export class LoginComponent {
 
-  constructor(private router: Router, private rs: RouteService) {}
+  constructor(private router: Router, private auth: AuthService) {}
 
   isSignup = false;
   loginData = { email: '', password: '' };
@@ -20,10 +20,10 @@ export class LoginComponent {
   }
 
   login() {
-    this.rs.login(this.loginData.email, this.loginData.password).subscribe({
+    this.auth.login(this.loginData.email, this.loginData.password).subscribe({
       next: (res: any) => {
         console.log('Login successful', res);
-        this.router.navigate(['/'], { state: { user: res.data } });
+        this.router.navigate(['/']);
       },
       error: (err: any) => {
         console.error('Login failed', err);
@@ -39,7 +39,7 @@ export class LoginComponent {
       return;
     }
 
-    this.rs
+    this.auth
       .register(this.signupData.email, this.signupData.password)
       .subscribe({
         next: (res) => {
@@ -52,5 +52,10 @@ export class LoginComponent {
           alert(err.error?.message || 'Signup failed');
         },
       });
+  }
+
+  logout() {
+    this.auth.logout();
+    this.router.navigate(['/login']);
   }
 }

--- a/src/app/services/auth.guard.ts
+++ b/src/app/services/auth.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(): boolean | UrlTree {
+    if (this.auth.isLoggedIn()) {
+      return true;
+    }
+    return this.router.parseUrl('/login');
+  }
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly baseUrl = 'http://localhost:8080/api/v1/';
+
+  constructor(private http: HttpClient) {}
+
+  login(email: string, password: string): Observable<any> {
+    return this.http
+      .post(`${this.baseUrl}auth/login`, { email, password })
+      .pipe(
+        tap((res: any) => {
+          if (res && res.token) {
+            localStorage.setItem('token', res.token);
+          }
+        })
+      );
+  }
+
+  register(email: string, password: string): Observable<any> {
+    return this.http
+      .post(`${this.baseUrl}auth/register`, { email, password })
+      .pipe(
+        tap((res: any) => {
+          if (res && res.token) {
+            localStorage.setItem('token', res.token);
+          }
+        })
+      );
+  }
+
+  isLoggedIn(): boolean {
+    return !!localStorage.getItem('token');
+  }
+
+  logout(): void {
+    localStorage.removeItem('token');
+  }
+}


### PR DESCRIPTION
## Summary
- create `AuthService` to persist token in localStorage
- implement `AuthGuard` to protect routes
- wire guard into routing module and add wildcard redirect
- update `LoginComponent` to use `AuthService`

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.*)*
- `npx ng test --watch=false` *(fails: npm 403 fetching ng)*

------
https://chatgpt.com/codex/tasks/task_e_6873586a49b88331945e29158d874c9f