### PR TITLE
Add auth guard and login persistence

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,13 +4,26 @@ import { HomeComponent } from './components/home/home.component';
 import { ProgramsComponent } from './components/programs/programs.component';
 import { AnalyicComponent } from './components/analyic/analyic.component'; // Adjust path if needed
 import { LoginComponent } from './components/login/login.component';
+import { AuthGuard } from './auth.guard';
 
 const routes: Routes = [
-  { path: '', component: HomeComponent },
-  { path: 'programs', component: ProgramsComponent },
-  { path: 'analytic', component: AnalyicComponent },
   { path: 'login', component: LoginComponent },
-  // Add more routes here if needed
+  {
+    path: '',
+    component: HomeComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'programs',
+    component: ProgramsComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'analytic',
+    component: AnalyicComponent,
+    canActivate: [AuthGuard],
+  },
+  { path: '**', redirectTo: '' },
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,8 @@ import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { ToastrModule } from 'ngx-toastr';
 import { RouteService } from './services/route.service';
+import { AuthService } from './services/auth.service';
+import { AuthGuard } from './auth.guard';
 
 @NgModule({
   declarations: [
@@ -51,7 +53,13 @@ import { RouteService } from './services/route.service';
     }),
     FormsModule,
   ],
-  providers: [GeneralService, ExerciseService, RouteService],
+  providers: [
+    GeneralService,
+    ExerciseService,
+    RouteService,
+    AuthService,
+    AuthGuard,
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthService } from './services/auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(): boolean | UrlTree {
+    if (this.auth.isLoggedIn) {
+      return true;
+    }
+    return this.router.parseUrl('/login');
+  }
+}

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { RouteService } from '../../services/route.service';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -8,8 +8,11 @@ import { RouteService } from '../../services/route.service';
   styleUrls: ['./login.component.scss'],
 })
 export class LoginComponent {
-
-  constructor(private router: Router, private rs: RouteService) {}
+  constructor(private router: Router, private auth: AuthService) {
+    if (this.auth.isLoggedIn) {
+      this.router.navigate(['/']);
+    }
+  }
 
   isSignup = false;
   loginData = { email: '', password: '' };
@@ -20,10 +23,10 @@ export class LoginComponent {
   }
 
   login() {
-    this.rs.login(this.loginData.email, this.loginData.password).subscribe({
+    this.auth.login(this.loginData.email, this.loginData.password).subscribe({
       next: (res: any) => {
         console.log('Login successful', res);
-        this.router.navigate(['/'], { state: { user: res.data } });
+        this.router.navigate(['/']);
       },
       error: (err: any) => {
         console.error('Login failed', err);
@@ -39,7 +42,7 @@ export class LoginComponent {
       return;
     }
 
-    this.rs
+    this.auth
       .register(this.signupData.email, this.signupData.password)
       .subscribe({
         next: (res) => {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { Router } from '@angular/router';
+import { RouteService } from './route.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private currentUserSubject = new BehaviorSubject<any>(null);
+
+  constructor(private routeService: RouteService, private router: Router) {
+    const storedUser = localStorage.getItem('currentUser');
+    if (storedUser) {
+      this.currentUserSubject.next(JSON.parse(storedUser));
+    }
+  }
+
+  get currentUser(): any {
+    return this.currentUserSubject.value;
+  }
+
+  get isLoggedIn(): boolean {
+    return !!this.currentUserSubject.value;
+  }
+
+  login(email: string, password: string): Observable<any> {
+    return this.routeService.login(email, password).pipe(
+      tap((res: any) => {
+        localStorage.setItem('currentUser', JSON.stringify(res));
+        this.currentUserSubject.next(res);
+      })
+    );
+  }
+
+  register(email: string, password: string): Observable<any> {
+    return this.routeService.register(email, password).pipe(
+      tap((res: any) => {
+        localStorage.setItem('currentUser', JSON.stringify(res));
+        this.currentUserSubject.next(res);
+      })
+    );
+  }
+
+  logout(): void {
+    localStorage.removeItem('currentUser');
+    this.currentUserSubject.next(null);
+    this.router.navigate(['/login']);
+  }
+}


### PR DESCRIPTION
## Summary
- enforce login before accessing main pages
- persist login state in new `AuthService`
- route login and register actions through `AuthService`
- provide `AuthGuard` to routing module

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm test` *(fails: ng command not found)*
- `npm run build` *(fails: ng command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68735a35227c8331ab2cfcf22dce85c1