### PR TITLE
Fix user storage

### DIFF
--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -5,14 +5,17 @@ import { RouteService } from '../../services/route.service';
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.component.html',
-  styleUrls: ['./profile.component.scss']
+  styleUrls: ['./profile.component.scss'],
 })
 export class ProfileComponent {
   user: any;
   editing = false;
   nameInput = '';
 
-  constructor(private auth: AuthService, private rs: RouteService) {
+  constructor(
+    private auth: AuthService,
+    private rs: RouteService,
+  ) {
     this.user = this.auth.currentUser || {};
   }
 
@@ -24,7 +27,7 @@ export class ProfileComponent {
   saveName() {
     const trimmed = this.nameInput.trim();
     if (trimmed) {
-      this.rs.updateUserName(this.user.id, trimmed).subscribe(() => {
+      this.rs.updateUserName(this.user._id, trimmed).subscribe(() => {
         this.user.name = trimmed;
         this.editing = false;
       });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -7,10 +7,13 @@ import { RouteService } from './route.service';
 export class AuthService {
   private currentUserSubject = new BehaviorSubject<any>(null);
 
-  constructor(private routeService: RouteService, private router: Router) {
+  constructor(
+    private routeService: RouteService,
+    private router: Router,
+  ) {
     const storedUser = localStorage.getItem('currentUser');
     if (storedUser) {
-      this.currentUserSubject.next(JSON.parse(storedUser).data);
+      this.currentUserSubject.next(JSON.parse(storedUser));
     }
   }
 
@@ -25,18 +28,24 @@ export class AuthService {
   login(email: string, password: string): Observable<any> {
     return this.routeService.login(email, password).pipe(
       tap((res: any) => {
-        localStorage.setItem('currentUser', JSON.stringify(res));
-        this.currentUserSubject.next(res.data?.user);
-      })
+        const user = res?.data?.user;
+        if (user) {
+          localStorage.setItem('currentUser', JSON.stringify(user));
+          this.currentUserSubject.next(user);
+        }
+      }),
     );
   }
 
   register(email: string, password: string): Observable<any> {
     return this.routeService.register(email, password).pipe(
       tap((res: any) => {
-        localStorage.setItem('currentUser', JSON.stringify(res));
-        this.currentUserSubject.next(res.data?.user);
-      })
+        const user = res?.data?.user;
+        if (user) {
+          localStorage.setItem('currentUser', JSON.stringify(user));
+          this.currentUserSubject.next(user);
+        }
+      }),
     );
   }
 


### PR DESCRIPTION
## Summary
- store the user object directly in `localStorage`
- update profile component to use `_id` when updating user name

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687371dd8adc8331819beb2671cd9e3b